### PR TITLE
docs: explain marketplace refresh for new plugin releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,12 @@ If you use the `skill-creator` skill, you can:
 - If you add or rename reference files, the README structure is auto-synced via GitHub Actions.
 - For same-repo PRs, `.github/workflows/sync-readme-references.yml` may commit and push the README sync change to your branch automatically.
 
+## Release Notes
+
+- Marketplace and plugin versions are stored in `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`.
+- The `Release` workflow bumps those files and tags the release from `main`.
+- If users report seeing an older plugin version after a release, ask them to refresh the marketplace with `/plugin marketplace update swift-testing-agent-skill` before reinstalling or updating the Skill.
+
 ## Validation and Packaging
 
 Run (replace `<path-to-skill-creator>` with your local install path):

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ To install this Skill for your personal use in Claude Code:
 /plugin install swift-testing-expert@swift-testing-agent-skill
 ```
 
+#### Updating After a Release
+If Claude Code still shows an older version after a new GitHub release, refresh the marketplace before reinstalling or updating the Skill:
+
+```bash
+/plugin marketplace update swift-testing-agent-skill
+```
+
+Claude Code reads available plugin versions from your local marketplace copy, so updating the marketplace is what pulls the latest `.claude-plugin/marketplace.json`.
+
 #### Project Configuration
 To automatically provide this Skill to everyone working in a repository, configure the repository's `.claude/settings.json`:
 


### PR DESCRIPTION
## Summary
- document that Claude Code may need an explicit marketplace refresh before a newly released plugin version appears
- add the `/plugin marketplace update swift-testing-agent-skill` workaround to the install docs
- note the same troubleshooting step in the contributor release notes for future triage

## Test plan
- [x] Review README and CONTRIBUTING changes for accuracy
- [x] Confirm the branch diff only adds documentation for the marketplace refresh workflow