### PR TITLE
fix: update skills path in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -25,6 +25,6 @@
     "apple"
   ],
   "skills": [
-    "./"
+    "./swift-testing-expert"
   ]
 }


### PR DESCRIPTION
## Summary

This skill stopped showing in Claude. A self-assessment showed that the configuration is incorrect. I manually added these changes to my local version, and it started showing up again.